### PR TITLE
👷 Automatically build on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,18 @@
+name: Publish package to GitHub Packages
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Publish package
+        run: mvn -B deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -52,4 +52,11 @@
 		</dependency>
 	</dependencies>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/addono/kafka-module-boot</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
First tried setting it up with the hosted version of JFrog artifactory, but I just cannot get authentication to work there, so I ended up using Github Packages, which "just worked"™️.

For now, this pipeline only triggers when you create a new release, after you bump the version go to releases in Github and create a new one and it will automatically kick-off.