### PR TITLE
CI: Auto publish and prepare next version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,17 +1,47 @@
-name: Publish package to GitHub Packages
+name: Publishes new release and prepares for next version
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - master
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+
+      - name: Release and prepare for next iteration
+        uses: qcastel/github-actions-maven-release@master
+        with:
+          maven-repo-server-id: github
+          maven-repo-server-username: ${{ github.actor }}
+          maven-repo-server-password: ${{ github.token }}
+
+          gpg-enabled: "false"
+
+          git-release-bot-name: "release-bot"
+          git-release-bot-email: "release-bot@example.com"
+
+          access-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Run the build again for the new tag
+      - name: Cleanup previous build
+        # Need elevated rights to clean, as previous steps created
+        # files owned by a different user than the current user
+        run: git reset --hard && sudo git clean -dffx
+
+      - name: Get commits pushed during releasing
+        run: git pull
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: Publish package
         run: mvn -B deploy
         env:

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,0 +1,22 @@
+name: Publish snapshot version on every push to dev
+
+on:
+  push:
+    branches:
+    - snapshot-*
+    - dev
+
+jobs:
+  publish:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Publish package
+        run: mvn -B deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -59,4 +59,12 @@
 			<url>https://maven.pkg.github.com/OneTrackingFramework/kafka-module-boot</url>
 		</repository>
 	</distributionManagement>
+
+	<scm>
+		<connection>scm:git:https://github.com/OneTrackingFramework/kafka-module-boot.git</connection>
+		<developerConnection>scm:git:https://github.com/OneTrackingFramework/kafka-module-boot.git</developerConnection>
+		<url>https://github.com/OneTrackingFramework/kafka-module-boot.git</url>
+		<tag>HEAD</tag>
+	</scm>
+
 </project>


### PR DESCRIPTION
So, right now the flow creates a new version for every push to master - including a build of the next snapshot even though it's still equivalent to the one which was just released.

In addition, the dev branch and snapshot-* branches will publish as well, overwriting current snapshot releases in the registry. It is not explicitly checked that the current release is a snapshot release, so it could create new releases.

So the dev flow I envision is working on dev and once a release is ready merging it into master to kickof the release.

Alternatively, it could be setup such that creating a tag or a new Github release kicks of the release pipeline, allowing snapshot releases to be build from master. Downside is that you need to manually name the release tag/gh release, which will then be ignored by Maven's release policy, as versioning is done in the code.